### PR TITLE
hotfix: change the variable report to be an instance variable not clsss variable

### DIFF
--- a/lg_payroll_api/utils/report_parameters.py
+++ b/lg_payroll_api/utils/report_parameters.py
@@ -22,7 +22,7 @@ class ReportParameters:
     __rep_match_args: dict = None
 
     def __init__(self, parameters: Union[list[Relatorio], list[dict]]) -> None:
-        self.
+        self.reports: list[Relatorio] = []
         for arg in parameters:
             if isinstance(arg, dict):
                 self.reports.append(Relatorio(**arg))

--- a/lg_payroll_api/utils/report_parameters.py
+++ b/lg_payroll_api/utils/report_parameters.py
@@ -7,7 +7,6 @@ from lg_payroll_api.utils.models import Relatorio
 class ReportParameters:
     """Aux class to configure report parameters to generate reports in LG system."""
 
-    reports: list[Relatorio] = []
     __from_to_keys = {
         "DtoRelatorio": "Relatorio",
         "EnumTipoArquivoGerado": "TipoArquivoGerado",
@@ -23,6 +22,7 @@ class ReportParameters:
     __rep_match_args: dict = None
 
     def __init__(self, parameters: Union[list[Relatorio], list[dict]]) -> None:
+        self.
         for arg in parameters:
             if isinstance(arg, dict):
                 self.reports.append(Relatorio(**arg))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lg-payroll-api"
-version = "0.1.9"
+version = "0.1.10"
 description = ""
 authors = ["stone_people_analytics <systems-techpeople@stone.com.br>"]
 maintainers = [


### PR DESCRIPTION
- Changes
The variable report was an class variable then the ReportParameters objects were sharing the same variable, change the report variable to be an instance variable