### PR TITLE
Feature/consult workshift method contracts service

### DIFF
--- a/lg_payroll_api/scripts/employment_contract.py
+++ b/lg_payroll_api/scripts/employment_contract.py
@@ -38,6 +38,25 @@ class LgApiEmploymentContract(BaseLgServiceClient):
                 )
             )
         )
+    
+    def consult_work_shift(self, contract_code: str, company_code: int) -> LgApiReturn:
+        body = {
+            "Colaborador": {
+                "Matricula": contract_code,
+                "Empresa": {"Codigo": company_code},
+            }
+        }
+
+        return LgApiReturn(
+            **serialize_object(
+                self.send_request(
+                    service_client=self.wsdl_client.service.ConsultarEscala,
+                    body=body,
+                )
+            )
+        )
+    
+    
 
     def consult_list(
         self,

--- a/lg_payroll_api/scripts/employment_contract.py
+++ b/lg_payroll_api/scripts/employment_contract.py
@@ -38,7 +38,7 @@ class LgApiEmploymentContract(BaseLgServiceClient):
                 )
             )
         )
-    
+
     def consult_work_shift(self, contract_code: str, company_code: int) -> LgApiReturn:
         body = {
             "Colaborador": {
@@ -55,8 +55,6 @@ class LgApiEmploymentContract(BaseLgServiceClient):
                 )
             )
         )
-    
-    
 
     def consult_list(
         self,

--- a/lg_payroll_api/scripts/movement.py
+++ b/lg_payroll_api/scripts/movement.py
@@ -255,6 +255,8 @@ class LgApiMovementClient(BaseLgServiceClient):
         timekeeping_required: bool = None,
         new_contract_type_code: str = None,
         observations: str = None,
+        class_description: str = None,
+        unlink_class: bool = None,
     ) -> LgApiSaveListReturn:
         """
         Registers a movement (transfer, update, or change) for a contract in the payroll system.
@@ -319,6 +321,8 @@ class LgApiMovementClient(BaseLgServiceClient):
             timekeeping_required (bool, optional): Whether timekeeping is required.
             new_contract_type_code (str, optional): Code of the new contract type.
             observations (str, optional): Additional observations.
+            class_description (str, optional): Description of the class.
+            unlink_class (bool, optional): Whether to unlink the class.
 
         Returns:
             LgApiExecReturn: The result of the movement registration operation.
@@ -490,6 +494,12 @@ class LgApiMovementClient(BaseLgServiceClient):
         if new_contract_type_code is not None:
             moved_items.append(factory_moved_items.ItemMovimentadoModalidadeContratual(
                 Codigo=new_contract_type_code,
+            ))
+        
+        if class_description is not None:
+            moved_items.append(factory_moved_items.ItemMovimentadoTurma(
+                Descricao=class_description,
+                Desvincular=bool_to_int(unlink_class),
             ))
 
         body = {

--- a/lg_payroll_api/scripts/organizational_unit.py
+++ b/lg_payroll_api/scripts/organizational_unit.py
@@ -3,12 +3,14 @@ from typing import Literal
 
 from zeep.helpers import serialize_object
 
-from lg_payroll_api.helpers.api_results import LgApiPaginationReturn, LgApiReturn
+from lg_payroll_api.helpers.api_results import LgApiPaginationReturn, LgApiReturn, LgApiExecReturn
 from lg_payroll_api.helpers.base_client import BaseLgServiceClient, LgAuthentication
 from lg_payroll_api.utils.enums import (
     EnumTipoDeDadosModificadosDaUnidadeOrganizacional,
     EnumTipoDeOperacao,
 )
+from lg_payroll_api.utils.enums import EnumTipoDeDepartamento, EnumTipoStatus, EnumTipoIdentificacaoGestor
+from lg_payroll_api.utils.aux_functions import bool_to_int
 
 
 class LgApiOrganizationalUnitClient(BaseLgServiceClient):
@@ -20,6 +22,108 @@ class LgApiOrganizationalUnitClient(BaseLgServiceClient):
     def __init__(self, lg_auth: LgAuthentication):
         super().__init__(
             lg_auth=lg_auth, wsdl_service="v1/ServicoDeUnidadeOrganizacional"
+        )
+    
+    def save(
+        self,
+        code: int,
+        description: str,
+        status: EnumTipoStatus,
+        company_code: int,
+        level: int,
+        start_date: date,
+        end_date: date = None,
+        parent_organizational_unit_code: int = None,
+        observation: str = None,
+        address_cep: str = None,
+        address_street_type_description: str = None,
+        address_street_type_code: int = None,
+        address_street: str = None,
+        address_number: str = None,
+        address_complement: str = None,
+        address_neighborhood: str = None,
+        address_city_code: str = None,
+        address_state_code: str = None,
+        address_country_code: str = None,
+        department_type: EnumTipoDeDepartamento = None,
+        allowed_companies_codes: list[int] = None,
+        allowed_offices_codes: list[int] = None,
+        short_description: str = None,
+        enable_employee_registration: bool = None,
+        manager_identification_type: EnumTipoIdentificacaoGestor = None,
+        manager_roles_codes: list[int] = None,
+        managers_positions_codes: list[int] = None,
+
+    ) -> LgApiExecReturn:
+        """LG API INFOS https://portalgentedesucesso.lg.com.br/api.aspx
+
+        Endpoint to save an organizational unit in LG System
+
+        Returns:
+            LgApiReturn: A List of OrderedDict that represents an Object(RetornoDeOperacao) API response
+                [
+                    Tipo : int
+                    Mensagens : [string]
+                    CodigoDoErro : string
+                    Retorno : string
+                ]
+        """
+        params = {
+            "Empresa":{"Codigo": company_code},
+            "Nivel": {"Codigo": level},
+            "DataFinal": end_date.strftime("%Y-%m-%d") if end_date else None,
+            "Observacao": observation,
+            "Endereco": {
+                "Cep": address_cep,
+                "TipoDeLogradouro": {
+                    "Descricao": address_street_type_description,
+                    "Codigo": address_street_type_code,
+                } if address_street_type_description or address_street_type_code else None,
+                "Logradouro": address_street,
+                "Numero": address_number,
+                "Complemento": address_complement,
+                "Bairro": address_neighborhood,
+                "Municipio": {
+                    "Codigo": address_city_code,
+                    "Estado": {
+                        "Codigo": address_state_code,
+                        "Pais": {"Codigo": address_country_code} if address_country_code else None,
+                    } if address_state_code or address_country_code else None,
+                } if address_city_code or address_state_code or address_country_code else None,
+            } if address_street or address_street_type_description else None,
+            "EnumTipoDeDepartamento": department_type,
+            "Habilitacoes": {
+                "Empresas": [
+                    {"Codigo": codigo} for codigo in allowed_companies_codes
+                ] if allowed_companies_codes else None,
+                "Cargos": [
+                    {"Codigo": codigo} for codigo in allowed_offices_codes
+                ] if allowed_offices_codes else None,
+            } if allowed_companies_codes or allowed_offices_codes else None,
+            "DescricaoResumida": short_description,
+            "PermiteCadastrarColaborador": bool_to_int(enable_employee_registration),
+            "IdentificacaoGestor": manager_identification_type,
+            "GestorCargo": [
+                {"Codigo": codigo} for codigo in manager_roles_codes
+            ] if manager_roles_codes else None,
+            "GestorPosicao": [
+                {"Codigo": codigo} for codigo in managers_positions_codes
+            ] if managers_positions_codes else None,
+            "UnidadeOrganizacionalSuperior": {"Codigo": parent_organizational_unit_code} if parent_organizational_unit_code else None,
+            "DataInicial": start_date.strftime("%Y-%m-%d"),
+            "Descricao": description,
+            "Status": status,
+            "Codigo": code,
+        }
+        
+        return LgApiExecReturn(
+            **serialize_object(
+                self.send_request(
+                    service_client=self.wsdl_client.service.Salvar,
+                    body=params,
+                    parse_body_on_request=False,
+                )
+            )
         )
 
     def consult_list(

--- a/lg_payroll_api/scripts/organizational_unit.py
+++ b/lg_payroll_api/scripts/organizational_unit.py
@@ -44,6 +44,7 @@ class LgApiOrganizationalUnitClient(BaseLgServiceClient):
         address_neighborhood: str = None,
         address_city_code: str = None,
         address_state_code: str = None,
+        address_state_acronym: str = None,
         address_country_code: str = None,
         department_type: EnumTipoDeDepartamento = None,
         allowed_companies_codes: list[int] = None,
@@ -87,10 +88,11 @@ class LgApiOrganizationalUnitClient(BaseLgServiceClient):
                     "Codigo": address_city_code,
                     "Estado": {
                         "Codigo": address_state_code,
+                        "Sigla": address_state_acronym,
                         "Pais": {"Codigo": address_country_code} if address_country_code else None,
-                    } if address_state_code or address_country_code else None,
+                    } if address_state_code or address_state_acronym or address_country_code else None,
                 } if address_city_code or address_state_code or address_country_code else None,
-            } if address_street or address_street_type_description else None,
+            } if address_street or address_street_type_code else None,
             "EnumTipoDeDepartamento": department_type,
             "Habilitacoes": {
                 "Empresas": [

--- a/lg_payroll_api/utils/enums.py
+++ b/lg_payroll_api/utils/enums.py
@@ -273,3 +273,14 @@ class EnumFormaDePagamento(int, Enum):
     RECIBO = 11
     PAGAMENTO_TED = 12
     PAGAMENTO_DINHEIRO = 13
+
+
+class EnumTipoDeDepartamento(int, Enum):
+    NORMAL = 0
+    STAFF = 1
+
+
+class EnumTipoIdentificacaoGestor(int, Enum):
+    CARGO = 1016
+    POSICAO = 1030
+    COLABORADOR = 1079

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lg-payroll-api"
-version = "0.1.17"
+version = "0.1.18"
 description = ""
 authors = ["stone_people_analytics <systems-techpeople@stone.com.br>"]
 maintainers = [


### PR DESCRIPTION
This pull request introduces a new endpoint for saving organizational units and adds supporting enums and utility imports to the codebase. Additionally, it adds a new method for consulting work shifts in employment contracts. These changes expand the API's capabilities for managing organizational data and work shifts.

### Organizational Unit Enhancements

* Added a new `save` method to `LgApiOrganizationalUnitClient` in `organizational_unit.py`, allowing the creation and update of organizational units with extensive parameters, including address, department type, manager info, and more. This method returns a structured API execution result.
* Imported new utility functions and enums (`EnumTipoDeDepartamento`, `EnumTipoStatus`, `EnumTipoIdentificacaoGestor`, `bool_to_int`) to support the new `save` method.
* Added new enums in `enums.py` for department type (`EnumTipoDeDepartamento`) and manager identification type (`EnumTipoIdentificacaoGestor`), supporting the organizational unit features.

### Employment Contract API

* Added a `consult_work_shift` method to `employment_contract.py` to allow querying an employee's work shift by contract and company code.

### Project Versioning

* Bumped the project version from `0.1.17` to `0.1.18` in `pyproject.toml` to reflect the new features.