### PR TITLE
Chore/adjust save additional info save method

### DIFF
--- a/lg_payroll_api/helpers/api_results.py
+++ b/lg_payroll_api/helpers/api_results.py
@@ -99,7 +99,7 @@ class LgApiSaveListReturn(BaseLgApiReturn):
         List[dict],
         List[OrderedDict],
         None
-    ]
+    ] = None
     IdentificadorDeOcorrencias: Union[
         dict,
         OrderedDict,

--- a/lg_payroll_api/scripts/additional_information_value.py
+++ b/lg_payroll_api/scripts/additional_information_value.py
@@ -1,6 +1,6 @@
 from zeep.helpers import serialize_object
 
-from lg_payroll_api.helpers.api_results import LgApiReturn, LgApiExecutionReturn
+from lg_payroll_api.helpers.api_results import LgApiReturn, LgApiSaveListReturn
 from lg_payroll_api.helpers.base_client import BaseLgServiceClient, LgAuthentication
 from lg_payroll_api.utils.enums import (
     EnumTipoEntidadeInformacaoAdicional, EnumIdentificadorInformacaoAdicional
@@ -102,23 +102,23 @@ class LgApiAdditionalInformationValueClient(BaseLgServiceClient):
         self,
         additional_info_code: int,
         additional_info_value: str,
-        entity_code:int,
-        company_code:int,
+        entity_code: int,
         entity_type: EnumIdentificadorInformacaoAdicional,
+        company_code: int = None,
         selected_options: list[str] = None
-    ) -> LgApiExecutionReturn:
+    ) -> LgApiSaveListReturn:
         """Save additional information value in LG System
 
         Args:
             additional_info_code (int, mandatory): Additional information identifier;
             additional_info_value (str, mandatory): Value to be saved in the additional information;
             entity_code (int, mandatory): Identifier of the entity related to the additional information value;
-            company_code (int, mandatory): Company code of the entity;
+            company_code (int, optional): Company code of the entity;
             entity_type (EnumIdentificadorInformacaoAdicional, mandatory): Type of the entity;
             selected_options (list[str], optional): List of selected options identifiers for the additional information value.
 
         Returns:
-            LgApiExecutionReturn: An OrderedDict that represents an Object(RetornoDeExecucao) API response
+            LgApiSaveListReturn: An OrderedDict that represents an Object(RetornoDeExecucao) API response
                 {
                     Tipo : int
                     Mensagens : [string]
@@ -140,14 +140,14 @@ class LgApiAdditionalInformationValueClient(BaseLgServiceClient):
             "IdentificadorDaEntidade": identificador,
             "Codigo": additional_info_code,
             "Valor" : additional_info_value,
-            "OpcoesSelecionadas": selected_options
+            "OpcoesSelecionadas": selected_options,
         }
         params = {
-            "ValorDaInformacaoAdicionalV2": [
+            "ValorDaInformacaoAdicional": [
                 params
             ]
         }
-        return LgApiExecutionReturn(
+        return LgApiSaveListReturn(
             **serialize_object(
                 self.send_request(
                     service_client=self.wsdl_client.service.SalvarLista,

--- a/lg_payroll_api/scripts/additional_information_value.py
+++ b/lg_payroll_api/scripts/additional_information_value.py
@@ -98,7 +98,6 @@ class LgApiAdditionalInformationValueClient(BaseLgServiceClient):
             )
         )
 
-    # TODO fix the problem with payload sended
     def save_additional_information_value(
         self,
         additional_info_code: int,
@@ -106,10 +105,27 @@ class LgApiAdditionalInformationValueClient(BaseLgServiceClient):
         entity_code:int,
         company_code:int,
         entity_type: EnumIdentificadorInformacaoAdicional,
+        selected_options: list[str] = None
     ) -> LgApiExecutionReturn:
-        """**WARNING**: This method is not working yet.
+        """Save additional information value in LG System
+
+        Args:
+            additional_info_code (int, mandatory): Additional information identifier;
+            additional_info_value (str, mandatory): Value to be saved in the additional information;
+            entity_code (int, mandatory): Identifier of the entity related to the additional information value;
+            company_code (int, mandatory): Company code of the entity;
+            entity_type (EnumIdentificadorInformacaoAdicional, mandatory): Type of the entity;
+            selected_options (list[str], optional): List of selected options identifiers for the additional information value.
+
+        Returns:
+            LgApiExecutionReturn: An OrderedDict that represents an Object(RetornoDeExecucao) API response
+                {
+                    Tipo : int
+                    Mensagens : [string]
+                    CodigoDoErro : string
+                }
         """
-        if isinstance(entity_type, EnumTipoEntidadeInformacaoAdicional):
+        if isinstance(entity_type, EnumIdentificadorInformacaoAdicional):
             entity_type = entity_type.value
 
         #Get the complex type for the entity
@@ -121,25 +137,22 @@ class LgApiAdditionalInformationValueClient(BaseLgServiceClient):
         )
         # Create the payload with the complex type
         params = {
-            "filtro": {
-                "Identificador": identificador,
-                "Código do conceito": additional_info_code,
-                "Valor" : additional_info_value
-            }
+            "IdentificadorDaEntidade": identificador,
+            "Codigo": additional_info_code,
+            "Valor" : additional_info_value,
+            "OpcoesSelecionadas": selected_options
         }
         params = {
-            "valores": {
-                "ValorDaInformacaoAdicional": [
-                    params
-                ]
-            }
+            "ValorDaInformacaoAdicionalV2": [
+                params
+            ]
         }
         return LgApiExecutionReturn(
             **serialize_object(
                 self.send_request(
                     service_client=self.wsdl_client.service.SalvarLista,
                     body=params,
-                    parse_body_on_request=True,
+                    parse_body_on_request=False,
                 )
             )
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lg-payroll-api"
-version = "0.1.20"
+version = "0.1.21"
 description = ""
 authors = ["stone_people_analytics <systems-techpeople@stone.com.br>"]
 maintainers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lg-payroll-api"
-version = "0.1.21"
+version = "0.1.20"
 description = ""
 authors = ["stone_people_analytics <systems-techpeople@stone.com.br>"]
 maintainers = [


### PR DESCRIPTION
This pull request updates the handling and saving of additional information values in the LG Payroll API. The main improvements include refactoring the `save_additional_information_value` method to support new parameters and response types, updating type hints and docstrings for clarity, and ensuring better compatibility with the expected API payload.

**Refactoring and API compatibility:**

* Refactored the `save_additional_information_value` method in `additional_information_value.py` to accept `company_code` and `selected_options` as optional parameters, updated the payload structure to match API requirements, and switched the return type to `LgApiSaveListReturn` for improved response handling. [[1]](diffhunk://#diff-e050a42bc1086c03c6f178e086e23b00ec2cbdfc5ebb4d2168bdcf8fa3f4b540L101-R128) [[2]](diffhunk://#diff-e050a42bc1086c03c6f178e086e23b00ec2cbdfc5ebb4d2168bdcf8fa3f4b540L124-R155)
* Updated the import statement in `additional_information_value.py` to use `LgApiSaveListReturn` instead of `LgApiExecutionReturn`, reflecting the new expected return type.

**Type hints and documentation:**

* Enhanced the docstring for `save_additional_information_value` to clearly document all arguments, their types, and the expected return value, improving usability for future developers.

**Type hint improvements:**

* Added a default value of `None` for the `List` type hint in `LgApiSaveListReturn` within `api_results.py`, ensuring proper initialization and type safety.

**Version update:**

* Bumped the package version in `pyproject.toml` from `0.1.20` to `0.1.21` to reflect these changes.